### PR TITLE
Adicionado parâmetro de scroll offset nas options do iframe

### DIFF
--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -26,7 +26,8 @@ export function registerFrames () {
             'token',
             'screen',
             'backButtonLabel',
-            'backButtonUrl'
+            'backButtonUrl',
+            'scrollOffset'
           ]
         )
       }


### PR DESCRIPTION
Basicamente, este parâmetro permitirá repassar para a Glowy app o valor do parâmetro `scroll-offset`, definido no embed code.